### PR TITLE
Enh/custom sliceorder

### DIFF
--- a/bips/workflows/scripts/u0a14c5b5899911e1bca80023dfa375f2/modular_nodes.py
+++ b/bips/workflows/scripts/u0a14c5b5899911e1bca80023dfa375f2/modular_nodes.py
@@ -157,7 +157,7 @@ def mod_realign(node,in_file,tr,do_slicetime,sliceorder,
                 else:
                     raise TypeError('sliceorder must be filepath or list')
 
-                slicetime.inputs.args ='-tpattern @%s' % os.path.abspath('afni_custom_order_file.txt')
+                slicetime.inputs.args ='-tpattern @%s' % os.path.abspath(order_file)
                 slicetime.inputs.tr = str(tr)+'s'
                 slicetime.inputs.outputtype = 'NIFTI_GZ'
                 res = slicetime.run()


### PR DESCRIPTION
Changed AFNI node in slicetime correction to be able to accept text files as sliceorders. Now the command will either accept a list or a filepath as input to sliceorder.
