### PR TITLE
Fix for QA_utils.py

### DIFF
--- a/bips/workflows/gablab/wips/scripts/QA_utils.py
+++ b/bips/workflows/gablab/wips/scripts/QA_utils.py
@@ -279,7 +279,7 @@ def tsnr_roi(roi=[1021],name='roi_flow',plot=False, onsets=False):
         roi_idx = np.genfromtxt(summary_file)[:,1].astype(int)
         roi_vals = np.genfromtxt(roi_file)
         roi_vals = np.atleast_2d(roi_vals)
-	rois2skip = [0, 2, 4, 5, 7, 14, 15, 24, 30, 31, 41, 43, 44, 46, 62, 63, 77, 80, 85, 1000, 2000]
+        rois2skip = [0, 2, 4, 5, 7, 14, 15, 24, 30, 31, 41, 43, 44, 46, 62, 63, 77, 80, 85, 1000, 2000]
         ids2remove = []
         for roi in rois2skip:
             idx, = np.nonzero(roi_idx==roi)


### PR DESCRIPTION
QA_utils.py crashed in roistripper with "too many indices" when summary file had comments or when roi_file had only one row. Corrected by built-in numpy comment stripping and forcing the roi array to at least a two dimensional array.
